### PR TITLE
Add Jest with basic unit test

### DIFF
--- a/app/utils/__tests__/format.test.ts
+++ b/app/utils/__tests__/format.test.ts
@@ -1,0 +1,12 @@
+import { extractFields } from '../format';
+
+describe('extractFields', () => {
+  it('should parse reference number, weight and date', () => {
+    const text = `Reference No. ABC123\nSome other line\nGW: 12.5 KGM\nCertification: Something FEBRUARY 9, 2024 more text`;
+    expect(extractFields(text)).toEqual({
+      referenceNo: 'ABC123',
+      weight: '12.5 KGM',
+      date: '202429',
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@google-cloud/documentai": "^8.12.0",
@@ -31,6 +32,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration and setup for TypeScript
- add a unit test for `extractFields`
- expose `npm test` script

## Testing
- `npm test` *(fails: jest not found)*