### PR TITLE
Fix reference number extraction

### DIFF
--- a/app/utils/format.ts
+++ b/app/utils/format.ts
@@ -5,7 +5,7 @@ export function extractFields(inputText: string) {
   const referenceNoMatch = inputText.match(referenceNoRegex);
   console.log(referenceNoMatch);
   if (referenceNoMatch) {
-    result["referenceNo"] = removeReferenceNo(referenceNoMatch[0].trim());
+    result["referenceNo"] = referenceNoMatch[1];
   }
 
   const gwRegex = /GW:\s*([\d\.]+)\s*KGM/;
@@ -24,10 +24,6 @@ export function extractFields(inputText: string) {
   console.log("this is result", result);
 
   return result;
-}
-
-function removeReferenceNo(text: string): string {
-  return text.replace(/Reference No\.:/, "").trim();
 }
 
 function formatDate(dateString: string): string {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@google-cloud/documentai": "^8.12.0",

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,0 +1,19 @@
+import { execSync } from 'child_process';
+import path, { dirname } from 'path';
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+import test from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// compile the TypeScript file to a temporary directory for testing
+const outDir = path.join(__dirname, 'dist');
+execSync(`mkdir -p ${outDir} && tsc app/utils/format.ts --module commonjs --target es2017 --outDir ${outDir}`);
+
+const { extractFields } = await import(path.join(outDir, 'format.js'));
+
+test('extractFields captures reference number', () => {
+  const input = 'Some text\nReference No. ABC123\nOther text';
+  const result = extractFields(input);
+  assert.strictEqual(result.referenceNo, 'ABC123');
+});


### PR DESCRIPTION
## Summary
- extract the captured reference number directly
- remove `removeReferenceNo` helper
- add unit test for reference number extraction
- allow running `npm test` with Node's built-in test runner

## Testing
- `npm test`