### PR TITLE
Fix variable names

### DIFF
--- a/app/components/DownloadKeywordExcel/index.tsx
+++ b/app/components/DownloadKeywordExcel/index.tsx
@@ -5,10 +5,10 @@ interface Props {
 }
 export default function DownloadKeywordExcel({ ocrResult }: Props) {
   const handleDownloadKeywordExcel = async () => {
-    const splitedText = ocrResult.split("CERTIFICATE OF ORIGIN");
+    const splitText = ocrResult.split("CERTIFICATE OF ORIGIN");
     const result = [];
 
-    for (const pageText of splitedText) {
+    for (const pageText of splitText) {
       const response = await fetch("/api/extract-keyword", {
         method: "POST",
         body: JSON.stringify(pageText),

--- a/app/components/OcrResult/index.tsx
+++ b/app/components/OcrResult/index.tsx
@@ -2,12 +2,12 @@ interface Props {
   ocrResult: string;
 }
 export default function OcrResult({ ocrResult }: Props) {
-  const splitedText = ocrResult.split("CERTIFICATE OF ORIGIN");
+  const splitText = ocrResult.split("CERTIFICATE OF ORIGIN");
   return (
     <div className="p-10 flex flex-col gap-2">
       <h2 className="text-rose-500">페이지별 추출된 텍스트 확인</h2>
 
-      {splitedText.map((text, index) => {
+      {splitText.map((text, index) => {
         return (
           <div
             key={index}


### PR DESCRIPTION
## Summary
- rename `splitedText` variable to `splitText`

## Testing
- `npm run lint` *(fails: next not found)*